### PR TITLE
BUG? FileSystemLoader searchpath should be list

### DIFF
--- a/mrQA/formatter.py
+++ b/mrQA/formatter.py
@@ -107,7 +107,7 @@ class HtmlFormatter(BaseFormatter):
         :param
         :return:
         """
-        fs_loader = jinja2.FileSystemLoader(searchpath=self.template_folder)
+        fs_loader = jinja2.FileSystemLoader(searchpath=[self.template_folder])
         extn = ['jinja2.ext.loopcontrols']
         template_env = jinja2.Environment(loader=fs_loader, extensions=extn)
 


### PR DESCRIPTION
```
 pip show jinja2 |grep Version
Version: 2.10

 ```

```
 File "/home/ni_tools/mrQA/mrQA/mrQA/formatter.py", line 110, in render
    fs_loader = jinja2.FileSystemLoader(searchpath=self.template_folder)
  File "/usr/lib/python3/dist-packages/jinja2/loaders.py", line 163, in __init__
    self.searchpath = list(searchpath)
TypeError: 'PosixPath' object is not iterable
```